### PR TITLE
Improve cssColorRegx to detect more cases of rgba usage

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -56,7 +56,7 @@ const hasColorPropKeys = [
   'fill',
 ]
 
-const cssColorRegx = /(#[a-f0-9]{8}|#[a-f0-9]{6}|#[a-f0-9]{3}|rgb *\( *[0-9]{1,3}%? *, *[0-9]{1,3}%? *, *[0-9]{1,3}%? *\)|rgba *\( *[0-9]{1,3}%? *, *[0-9]{1,3}%? *, *[0-9]{1,3}%? *, (0.\d+|0|1)? *\)|black|green|silver|gray|olive|white|yellow|maroon|navy|red|blue|purple|teal|fuchsia|aqua)$/i
+const cssColorRegx = /(#[a-f0-9]{8}|#[a-f0-9]{6}|#[a-f0-9]{3}|rgb *\( *[0-9]{1,3}%? *, *[0-9]{1,3}%? *, *[0-9]{1,3}%? *\)|rgba *\( *[0-9]{1,3}%? *, *[0-9]{1,3}%? *, *[0-9]{1,3}%? *,\s?(0?.\d+|0|1)? *\)|black|green|silver|gray|olive|white|yellow|maroon|navy|red|blue|purple|teal|fuchsia|aqua)$/i
 
 function isValidAtomicRule(node) {
   const currentProp = node.prop


### PR DESCRIPTION
This PR makes the following usages to be detected as violations:
```css
rgba(0,0,0, 1) /* Note the space before 1 */
rgba(0,0,0,.5) /* 0.5 opacity can be expressed as .5, and this plugin was missing this scenario */
``` 

Currently, the above examples would not be detected as a violation by the plugin. This PR makes it detect them,